### PR TITLE
Patching compiler for various enhancement features

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This fork integrates a few tweak on the HTML renderer to make the documentation 
 * Support for Markdown in any `doc:` component
 * Wrap data types in code blocks for increased readability
 * Where possible, output field sizes so tables can be followed more easily
+* Documents `valid:` blocks from the specification in the table for `seq` elements and `types` tables.
 
 ## Further information
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ languages. These modules will include the generated code for a parser
 that can read described data structure from a file / stream and give
 access to it in a nice, easy-to-comprehend API.
 
+## Fork Status
+
+This fork integrates a few tweak on the HTML renderer to make the documentation slightly more functional for a reference viewer. These are:
+
+* Support for Markdown in any `doc:` component
+* Wrap data types in code blocks for increased readability
+* Where possible, output field sizes so tables can be followed more easily
+
 ## Further information
 
 If you're looking for information on:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ access to it in a nice, easy-to-comprehend API.
 This fork integrates a few tweak on the HTML renderer to make the documentation slightly more functional for a reference viewer. These are:
 
 * Support for Markdown in any `doc:` component
+    * Including tables
 * Wrap data types in code blocks for increased readability
 * Where possible, output field sizes so tables can be followed more easily
 * Documents `valid:` blocks from the specification in the table for `seq` elements and `types` tables.

--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,8 @@ lazy val compiler = crossProject.in(file(".")).
     Compile / mainClass := Some("io.kaitai.struct.JavaMain"),
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "3.2.12" % "test",
-      "org.commonmark" % "commonmark" % "0.20.0"
+      "org.commonmark" % "commonmark" % "0.20.0",
+      "org.commonmark" % "commonmark-ext-gfm-tables" % "0.21.0"
     ),
 
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", "target/test_out"),

--- a/build.sbt
+++ b/build.sbt
@@ -72,15 +72,16 @@ lazy val compiler = crossProject.in(file(".")).
     libraryDependencies ++= Seq(
       "com.github.scopt" %%% "scopt" % "3.6.0",
       "com.lihaoyi" %%% "fastparse" % "1.0.0",
-      "org.yaml" % "snakeyaml" % "1.28"
-    )
+      "org.yaml" % "snakeyaml" % "1.28",
+    ),
   ).
   jvmSettings(
     name := NAME,
 
     Compile / mainClass := Some("io.kaitai.struct.JavaMain"),
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.2.12" % "test"
+      "org.scalatest" %% "scalatest" % "3.2.12" % "test",
+      "org.commonmark" % "commonmark" % "0.20.0"
     ),
 
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", "target/test_out"),
@@ -180,6 +181,7 @@ lazy val compiler = crossProject.in(file(".")).
   ).
   jsSettings(
     name := NAME + "-js",
+    libraryDependencies += "com.github.karasiq" %%% "scalajs-marked" % "1.0.2",
     buildNpmJsFile := buildNpmJsFileTask.value,
     buildNpmPackage := buildNpmPackageTask.value
   )

--- a/js/src/main/scala/io/kaitai/struct/Platform.scala
+++ b/js/src/main/scala/io/kaitai/struct/Platform.scala
@@ -1,11 +1,16 @@
 package io.kaitai.struct
 
-import com.karasiq.markedjs.Marked
+import com.karasiq.markedjs.{Marked, MarkedOptions}
+
+import scala.scalajs.js.undefined
 
 object Platform {
     def toUpperLocaleInsensitive(s: String) = s.toUpperCase()
 
   def markdownToHtml(s: String): String = {
-    Marked(s)
+    Marked(s, MarkedOptions(
+      gfm = true,
+      tables = true,
+    ))
   }
 }

--- a/js/src/main/scala/io/kaitai/struct/Platform.scala
+++ b/js/src/main/scala/io/kaitai/struct/Platform.scala
@@ -1,5 +1,11 @@
 package io.kaitai.struct
 
+import com.karasiq.markedjs.Marked
+
 object Platform {
     def toUpperLocaleInsensitive(s: String) = s.toUpperCase()
+
+  def markdownToHtml(s: String): String = {
+    Marked(s)
+  }
 }

--- a/jvm/src/main/scala/io/kaitai/struct/Platform.scala
+++ b/jvm/src/main/scala/io/kaitai/struct/Platform.scala
@@ -1,16 +1,28 @@
 package io.kaitai.struct
 
+import org.commonmark.Extension
+import org.commonmark.ext.gfm.tables.TablesExtension
+
 import java.util.Locale
 import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer
+
+import java.util
 
 object Platform {
   def toUpperLocaleInsensitive(s: String) = s.toUpperCase(Locale.ROOT)
 
   def markdownToHtml(s: String): String = {
-    val parser = Parser.builder().build()
+    val extensions = util.Arrays.asList(TablesExtension.create())
+    val parser = Parser
+      .builder()
+      .extensions(extensions)
+      .build()
     val document = parser.parse(s)
-    val renderer = HtmlRenderer.builder().build()
+    val renderer = HtmlRenderer
+      .builder()
+      .extensions(extensions)
+      .build()
     renderer.render(document)
   }
 

--- a/jvm/src/main/scala/io/kaitai/struct/Platform.scala
+++ b/jvm/src/main/scala/io/kaitai/struct/Platform.scala
@@ -1,7 +1,17 @@
 package io.kaitai.struct
 
 import java.util.Locale
+import org.commonmark.parser.Parser
+import org.commonmark.renderer.html.HtmlRenderer
 
 object Platform {
-    def toUpperLocaleInsensitive(s: String) = s.toUpperCase(Locale.ROOT)
+  def toUpperLocaleInsensitive(s: String) = s.toUpperCase(Locale.ROOT)
+
+  def markdownToHtml(s: String): String = {
+    val parser = Parser.builder().build()
+    val document = parser.parse(s)
+    val renderer = HtmlRenderer.builder().build()
+    renderer.render(document)
+  }
+
 }

--- a/shared/src/main/scala/io/kaitai/struct/DocClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/DocClassCompiler.scala
@@ -2,11 +2,11 @@ package io.kaitai.struct
 
 import io.kaitai.struct.format._
 import io.kaitai.struct.precompile.CalculateSeqSizes
-import io.kaitai.struct.translators.RubyTranslator
+import io.kaitai.struct.translators.{BaseTranslator, RubyTranslator}
 
 abstract class DocClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends AbstractCompiler {
   val provider = new ClassTypeProvider(classSpecs, topClass)
-  val translator = new RubyTranslator(provider)
+  protected var translator: BaseTranslator = new RubyTranslator(provider)
 
   // TODO: move it into SingleOutputFile equivalent
   val out = new StringLanguageOutputWriter(indent)

--- a/shared/src/main/scala/io/kaitai/struct/HtmlClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/HtmlClassCompiler.scala
@@ -78,7 +78,19 @@ class HtmlClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends Doc
   override def compileSeqAttr(classSpec: ClassSpec, attr: AttrSpec, seqPos: Option[Int], sizeElement: Sized, sizeContainer: Sized): Unit = {
     out.puts("<tr>")
     out.puts(s"<td>${GraphvizClassCompiler.seqPosToStr(seqPos).getOrElse("???")}</td>")
-    out.puts(s"<td>...</td>")
+    sizeElement match {
+      case DynamicSized => out.puts(s"<td>dyn</td>")
+      case FixedSized(n) => {
+        if (n > 8 && n % 8 == 0){
+          out.puts(s"<td>${n / 8}&nbsp;byte${if (n > 8) "s" else ""}</td>")
+        }else{
+          out.puts(s"<td>${n}&nbsp;bit${if (n > 1) "s" else ""}</td>")
+        }
+      }
+      case NotCalculatedSized => out.puts(s"<td>???</td>")
+      case StartedCalculationSized => out.puts(s"<td>???</td>")
+    }
+//    out.puts(s"<td>...</td>")
     out.puts(s"<td>${attr.id.humanReadable}</td>")
     out.puts(s"<td>${kaitaiType2NativeType(attr.dataType)}</td>")
     out.puts(s"<td>${Platform.markdownToHtml(attr.doc.summary.getOrElse(""))}</td>")

--- a/shared/src/main/scala/io/kaitai/struct/HtmlClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/HtmlClassCompiler.scala
@@ -57,7 +57,7 @@ class HtmlClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends Doc
     out.puts
 
     classSpec.doc.summary.foreach(summary =>
-      out.puts(s"<p>$summary</p>")
+      out.puts(s"<p>${Platform.markdownToHtml(summary)}</p>")
     )
     out.inc
   }
@@ -81,7 +81,7 @@ class HtmlClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends Doc
     out.puts(s"<td>...</td>")
     out.puts(s"<td>${attr.id.humanReadable}</td>")
     out.puts(s"<td>${kaitaiType2NativeType(attr.dataType)}</td>")
-    out.puts(s"<td>${attr.doc.summary.getOrElse("")}</td>")
+    out.puts(s"<td>${Platform.markdownToHtml(attr.doc.summary.getOrElse(""))}</td>")
     out.puts("</tr>")
   }
 
@@ -93,7 +93,7 @@ class HtmlClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends Doc
     out.puts(s"<td>...</td>")
     out.puts(s"<td>${inst.id.humanReadable}</td>")
     out.puts(s"<td>${kaitaiType2NativeType(inst.dataType)}</td>")
-    out.puts(s"<td>${inst.doc.summary.getOrElse("")}</td>")
+    out.puts(s"<td>${Platform.markdownToHtml(inst.doc.summary.getOrElse(""))}</td>")
     out.puts("</tr>")
     out.puts("</table>")
   }
@@ -114,7 +114,7 @@ class HtmlClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends Doc
 
     enumColl.sortedSeq.foreach { case (id, value) =>
       out.puts("<tr>")
-      out.puts(s"<td>$id</td><td>${value.name}</td><td>${value.doc.summary.getOrElse("")}</td></tr>")
+      out.puts(s"<td>$id</td><td>${value.name}</td><td>${Platform.markdownToHtml(value.doc.summary.getOrElse(""))}</td></tr>")
       out.puts("</tr>")
     }
 

--- a/shared/src/main/scala/io/kaitai/struct/HtmlClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/HtmlClassCompiler.scala
@@ -92,7 +92,7 @@ class HtmlClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends Doc
     }
 //    out.puts(s"<td>...</td>")
     out.puts(s"<td>${attr.id.humanReadable}</td>")
-    out.puts(s"<td>${kaitaiType2NativeType(attr.dataType)}</td>")
+    out.puts(s"<td><code>${kaitaiType2NativeType(attr.dataType)}</code></td>")
     out.puts(s"<td>${Platform.markdownToHtml(attr.doc.summary.getOrElse(""))}</td>")
     out.puts("</tr>")
   }

--- a/shared/src/main/scala/io/kaitai/struct/translators/HTMLTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/HTMLTranslator.scala
@@ -1,0 +1,10 @@
+package io.kaitai.struct.translators
+
+import io.kaitai.struct.ImportList
+import io.kaitai.struct.datatype.DataType
+import io.kaitai.struct.exprlang.Ast
+
+class HTMLTranslator(provider: TypeProvider) extends JavaTranslator(provider, new ImportList()) {
+  override def doByteArrayLiteral(arr: Seq[Byte]): String =
+    s"[ ${arr.mkString(", ")} ]"
+}


### PR DESCRIPTION
This aims to make main the primary branch for work from here forward instead of this side branch. This branch includes the following improvements to the base compiler:

* Full markdown support
* Data types are wrapped in code blocks for readability
* Field sizes are displayed more clearly
* Validation blocks are now printed in a slightly nicer format for some supported expressions

These changes only impact the html rendering.